### PR TITLE
fix: map improvements + getCurrentLocation helper

### DIFF
--- a/packages/mapbox/docs/helpers/getCurrentPosition.story.mdx
+++ b/packages/mapbox/docs/helpers/getCurrentPosition.story.mdx
@@ -1,0 +1,36 @@
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import getCurrentPosition from '../../src/helpers/getCurrentPosition';
+import * as stories from '../stories/getCurrentPosition.story.js';
+
+<Meta title="Modules|Mapbox/Helpers" component={getCurrentPosition} />
+
+# Overview
+
+The `getCurrentPosition` method retrieves the current geographic location of the device. The location is expressed as a set of geographic coordinates together with information about heading and speed. The location information is returned in a Position object.
+
+### This is a basic example.
+
+<Preview>
+    <Story name="Mapbox">{stories.GetUserCurrentPosition()}</Story>
+</Preview>
+
+## Usage:
+
+```js
+try {
+    const position = await getCurrentPosition(geoOptions);
+} catch (error) {
+    // ...
+}
+```
+
+### Params
+
+| Property   | Description                                                                                                                                                                                                                                                   | Type   | Default                                                          |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ---------------------------------------------------------------- |
+| geoOptions | This optional parameter specifies a set of options for retrieving the location information. You can specify (a) Accuracy of the returned location information (b) Timeout for retrieving the location information and (c) Use of cached location information. | Object | { maximumAge: 600000, enableHighAccuracy: true, timeout: 10000 } |
+
+### Return Promise(resolve: GeolocationPosition || reject: GeolocationPositionError)
+
+-   [GeolocationPosition](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPosition)
+-   [GeolocationPositionError](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError)

--- a/packages/mapbox/docs/stories/Map.story.js
+++ b/packages/mapbox/docs/stories/Map.story.js
@@ -23,6 +23,7 @@ export const mapWithRoute = () => {
         <Application>
             <MapBox accessToken={MAPBOX_ACCESS_TOKEN} center={[-103.3291727, 20.607034]} zoom={15}>
                 <Route
+                    disableAnimation
                     waypoints={[
                         [-103.3491727, 20.677034],
                         [-103.301488, 20.526721],

--- a/packages/mapbox/docs/stories/getCurrentPosition.story.js
+++ b/packages/mapbox/docs/stories/getCurrentPosition.story.js
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { RainbowFirebaseApp, showAppSpinner, hideAppSpinner } from '@rainbow-modules/app';
+import { Button, RenderIf } from 'react-rainbow-components';
+import { RecordDetails, RecordField } from '@rainbow-modules/record';
+
+import getCurrentPostion from '../../src/helpers/getCurrentPosition';
+import app from '../../../../firebase';
+
+export const GetUserCurrentPosition = () => {
+    const [coords, setCoords] = useState(false);
+    const handleClick = async () => {
+        showAppSpinner();
+        const { coords } = await getCurrentPostion();
+        if (coords) {
+            setCoords(coords);
+        }
+        hideAppSpinner();
+    };
+    return (
+        <RainbowFirebaseApp app={app}>
+            <Button label="Get your current position" onClick={handleClick} />
+            <RenderIf isTrue={coords}>
+                <RecordDetails>
+                    <RecordField label="Latitude" value={coords.latitude} />
+                    <RecordField label="Longitude" value={coords.longitude} />
+                </RecordDetails>
+            </RenderIf>
+        </RainbowFirebaseApp>
+    );
+};
+
+export default {
+    title: 'Modules|Mapbox/Stories/Helpers',
+};

--- a/packages/mapbox/package.json
+++ b/packages/mapbox/package.json
@@ -12,6 +12,10 @@
         "mapbox-gl": "^1.12.0",
         "styled-components": "^4.3.2"
     },
+    "devDependencies": {
+        "@rainbow-modules/app": "^0.13.0",
+        "@rainbow-modules/record": "^0.13.0"
+    },
     "peerDependencies": {
         "react": ">=16.8.0",
         "react-rainbow-components": ">=1.15.0"

--- a/packages/mapbox/src/components/Map/__test__/map.spec.js
+++ b/packages/mapbox/src/components/Map/__test__/map.spec.js
@@ -53,63 +53,6 @@ describe('<Map />', () => {
             zoom: 9,
         });
     });
-    it('should call navigator.geolocation.getCurrentPosition when center is not passed', () => {
-        const mockGeolocation = { getCurrentPosition: jest.fn() };
-        global.navigator.geolocation = mockGeolocation;
-
-        mount(
-            <Application>
-                <Map accessToken="qwerty" zoom={9} />
-            </Application>,
-        );
-        expect(mockGeolocation.getCurrentPosition).toBeCalled();
-    });
-    it('should init map with resolved position', () => {
-        const mockGeolocation = {
-            getCurrentPosition: jest.fn().mockImplementationOnce((success) =>
-                Promise.resolve(
-                    success({
-                        coords: { latitude: 51.1, longitude: 45.3 },
-                    }),
-                ),
-            ),
-        };
-        global.navigator.geolocation = mockGeolocation;
-
-        mount(
-            <Application>
-                <Map accessToken="qwerty" defaultCenter={[-70.5, 31]} zoom={9} />
-            </Application>,
-        );
-        expect(mapboxgl.Map).toBeCalledWith({
-            accessToken: 'qwerty',
-            center: [45.3, 51.1],
-            container: expect.any(Node),
-            style: 'mapbox://styles/mapbox/light-v10',
-            zoom: 9,
-        });
-    });
-    it('should init map with the default center passed', () => {
-        const mockGeolocation = {
-            getCurrentPosition: jest
-                .fn()
-                .mockImplementationOnce((_success, error) => Promise.resolve(error())),
-        };
-        global.navigator.geolocation = mockGeolocation;
-
-        mount(
-            <Application>
-                <Map accessToken="qwerty" defaultCenter={[-70.5, 31]} zoom={9} />
-            </Application>,
-        );
-        expect(mapboxgl.Map).toBeCalledWith({
-            accessToken: 'qwerty',
-            center: [-70.5, 31],
-            container: expect.any(Node),
-            style: 'mapbox://styles/mapbox/light-v10',
-            zoom: 9,
-        });
-    });
     it('should render the children passed', () => {
         const component = mount(
             <Application>

--- a/packages/mapbox/src/components/Map/index.js
+++ b/packages/mapbox/src/components/Map/index.js
@@ -8,21 +8,15 @@ import { Container, MapContainer, ChildrenContainer } from './styled';
 
 const MapContext = createContext({});
 
-const geoOptions = {
-    maximumAge: 600000,
-    enableHighAccuracy: true,
-    timeout: 10000,
-};
-
 export default function Map(props) {
     const {
         accessToken,
         center,
-        defaultCenter,
         zoom,
         mapStyle,
         className,
         style,
+        disableAnimation,
         children,
     } = props;
     const mapContainerRef = useRef();
@@ -30,11 +24,11 @@ export default function Map(props) {
     const [context, setContext] = useState({ accessToken });
     const [isLoading, setLoading] = useState(false);
 
-    const renderMap = (mapCenter) => {
+    const renderMap = ({ center }) => {
         map.current = new mapboxgl.Map({
             container: mapContainerRef.current,
             style: mapStyle,
-            center: mapCenter,
+            center,
             zoom,
             accessToken,
         });
@@ -43,23 +37,10 @@ export default function Map(props) {
         setContext({ ...context, map: map.current });
     };
 
-    const handleGeolocationSuccess = (position) => {
-        const userLocation = [position.coords.longitude, position.coords.latitude];
-        renderMap(userLocation);
-    };
-
     useEffect(() => {
         if (accessToken) {
             setLoading(true);
-            if (Array.isArray(center) && center.length === 2) {
-                renderMap(center);
-            } else {
-                navigator.geolocation.getCurrentPosition(
-                    handleGeolocationSuccess,
-                    () => renderMap(defaultCenter),
-                    geoOptions,
-                );
-            }
+            renderMap({ center });
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [accessToken]);
@@ -68,8 +49,10 @@ export default function Map(props) {
         if (map.current && typeof map.current.flyTo === 'function') {
             map.current.flyTo({
                 center,
+                animate: !disableAnimation,
             });
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [center]);
 
     return (
@@ -106,8 +89,8 @@ Map.propTypes = {
     zoom: PropTypes.number,
     /** An array with the coordinates where the map will be centered when rendered */
     center: PropTypes.arrayOf(PropTypes.number),
-    /** An array with the coordinates where the map will be centered when it does not have a center prop and the location of the device fails */
-    defaultCenter: PropTypes.arrayOf(PropTypes.number),
+    /** It disable the animation when the center prop changes values */
+    disableAnimation: PropTypes.bool,
     children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.object]),
 };
 
@@ -117,6 +100,6 @@ Map.defaultProps = {
     mapStyle: 'mapbox://styles/mapbox/light-v10',
     zoom: 9,
     center: undefined,
-    defaultCenter: undefined,
     children: null,
+    disableAnimation: false,
 };

--- a/packages/mapbox/src/components/Route/index.js
+++ b/packages/mapbox/src/components/Route/index.js
@@ -11,7 +11,7 @@ import finish from './icons/finish';
 const fitBoundsPadding = { top: 350, left: 200, right: 200, bottom: 200 };
 
 export default function Route(props) {
-    const { waypoints, onRenderRoute } = props;
+    const { waypoints, onRenderRoute, disableAnimation } = props;
     const { accessToken, map } = useContext(Map.context);
     const uniqueId = useUniqueIdentifier('mapbox-route');
 
@@ -72,6 +72,7 @@ export default function Route(props) {
 
                     map.fitBounds(waypoints, {
                         padding: fitBoundsPadding,
+                        animate: !disableAnimation,
                     });
 
                     onRenderRoute({
@@ -101,9 +102,11 @@ export default function Route(props) {
 Route.propsTypes = {
     waypoints: PropTypes.array,
     onRenderRoute: PropTypes.func,
+    disableAnimation: PropTypes.bool,
 };
 
 Route.defaultProps = {
     waypoints: [],
     onRenderRoute: () => {},
+    disableAnimation: false,
 };

--- a/packages/mapbox/src/helpers/getCurrentPosition.js
+++ b/packages/mapbox/src/helpers/getCurrentPosition.js
@@ -1,0 +1,13 @@
+const defaultGeoOptions = {
+    maximumAge: 600000,
+    enableHighAccuracy: true,
+    timeout: 10000,
+};
+
+const getCurrentPosition = (geoOptions = defaultGeoOptions) => {
+    return new Promise((resolve, reject) => {
+        navigator.geolocation.getCurrentPosition(resolve, reject, geoOptions);
+    });
+};
+
+export default getCurrentPosition;

--- a/packages/mapbox/src/index.js
+++ b/packages/mapbox/src/index.js
@@ -1,2 +1,3 @@
 export { default as Map } from './components/Map';
 export { default as Route } from './components/Route';
+export { default as getCurrentPosition } from './helpers/getCurrentPosition';


### PR DESCRIPTION
- map won't fallback to the current location when no center was passed
- map deprecate `defautlCenter` since it doesn't make sense anymore
- new prop `disableAnimation` that disable animation when the center prop changes values
- new public helper `getCurrentPosition`