### PR TITLE
fix: `RecordField` with `type="dateTime" crashes when pass a string date or a new Date(string)

### DIFF
--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -9,6 +9,7 @@
     ],
     "dependencies": {
         "@rainbow-modules/icons": "^0.14.0",
+        "@rainbow-modules/validation": "^0.14.0",
         "styled-components": "^4.3.2"
     },
     "peerDependencies": {

--- a/packages/record/src/components/RecordField/__test__/recordField.spec.js
+++ b/packages/record/src/components/RecordField/__test__/recordField.spec.js
@@ -20,7 +20,7 @@ describe('<Tile />', () => {
         const values = [
             { date: '01/01/2020', formated: '1/1/2020, 12:00:00 AM' },
             { date: '01-01-2020', formated: '1/1/2020, 12:00:00 AM' },
-            { date: 0, formated: '12/31/1969, 7:00:00 PM' },
+            { date: 0, formated: '1/1/1970, 12:00:00 AM' },
             { date: new Date('01-01-2020'), formated: '1/1/2020, 12:00:00 AM' },
         ];
         values.forEach(({ date, formated }) => {

--- a/packages/record/src/components/RecordField/__test__/recordField.spec.js
+++ b/packages/record/src/components/RecordField/__test__/recordField.spec.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Application } from 'react-rainbow-components';
+import RecordField from '..';
+import Value from '../value';
+
+describe('<Tile />', () => {
+    it('should render empty when type is dateTime and value is not datetime', () => {
+        const values = ['', 'test', [], {}, undefined, null];
+        values.forEach((value) => {
+            const wrapper = mount(
+                <Application>
+                    <RecordField type="dateTime" value={value} />
+                </Application>,
+            );
+            expect(wrapper.find(Value).text()).toBe('');
+        });
+    });
+    it('should render a formated date when type is dateTime and value is datetime', () => {
+        const values = [
+            { date: '01/01/2020', formated: '1/1/2020, 12:00:00 AM' },
+            { date: '01-01-2020', formated: '1/1/2020, 12:00:00 AM' },
+            { date: 0, formated: '12/31/1969, 7:00:00 PM' },
+            { date: new Date('01-01-2020'), formated: '1/1/2020, 12:00:00 AM' },
+        ];
+        values.forEach(({ date, formated }) => {
+            const wrapper = mount(
+                <Application>
+                    <RecordField type="dateTime" value={date} />
+                </Application>,
+            );
+            expect(wrapper.find(Value).text()).toBe(formated);
+        });
+    });
+});

--- a/packages/record/src/components/RecordField/helpers/valueFormatter.js
+++ b/packages/record/src/components/RecordField/helpers/valueFormatter.js
@@ -1,4 +1,4 @@
-import { isNumber } from '@rainbow-modules/validation';
+import { isNull, isNumber } from '@rainbow-modules/validation';
 
 export const currency = (value, currency) => {
     return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(value);
@@ -14,13 +14,17 @@ export const percent = (value) => {
     }).format(value);
 };
 
-const isValidDate = (date) => {
-    return isNumber(date.getTime());
+const initDate = (value) => {
+    if (!isNull(value)) {
+        const date = new Date(value);
+        return isNumber(date.getTime()) && date;
+    }
+    return undefined;
 };
 
 export const dateTime = (value) => {
-    const date = new Date(value);
-    if (isValidDate(date)) {
+    const date = initDate(value);
+    if (date) {
         return new Intl.DateTimeFormat(undefined, {
             year: 'numeric',
             month: 'numeric',
@@ -34,16 +38,16 @@ export const dateTime = (value) => {
 };
 
 export const date = (value) => {
-    const date = new Date(value);
-    if (isValidDate(date)) {
+    const date = initDate(value);
+    if (date) {
         return new Intl.DateTimeFormat().format(date);
     }
     return '';
 };
 
 export const time = (value) => {
-    const date = new Date(value);
-    if (isValidDate(date)) {
+    const date = initDate(value);
+    if (date) {
         return new Intl.DateTimeFormat(undefined, {
             hour: 'numeric',
             minute: 'numeric',

--- a/packages/record/src/components/RecordField/helpers/valueFormatter.js
+++ b/packages/record/src/components/RecordField/helpers/valueFormatter.js
@@ -1,3 +1,5 @@
+import { isNumber } from '@rainbow-modules/validation';
+
 export const currency = (value, currency) => {
     return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(value);
 };
@@ -12,27 +14,43 @@ export const percent = (value) => {
     }).format(value);
 };
 
+const isValidDate = (date) => {
+    return isNumber(date.getTime());
+};
+
 export const dateTime = (value) => {
-    return new Intl.DateTimeFormat(undefined, {
-        year: 'numeric',
-        month: 'numeric',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: 'numeric',
-        second: 'numeric',
-    }).format(value);
+    const date = new Date(value);
+    if (isValidDate(date)) {
+        return new Intl.DateTimeFormat(undefined, {
+            year: 'numeric',
+            month: 'numeric',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: 'numeric',
+            second: 'numeric',
+        }).format(date);
+    }
+    return '';
 };
 
 export const date = (value) => {
-    return new Intl.DateTimeFormat().format(value);
+    const date = new Date(value);
+    if (isValidDate(date)) {
+        return new Intl.DateTimeFormat().format(date);
+    }
+    return '';
 };
 
 export const time = (value) => {
-    return new Intl.DateTimeFormat(undefined, {
-        hour: 'numeric',
-        minute: 'numeric',
-        second: 'numeric',
-    }).format(value);
+    const date = new Date(value);
+    if (isValidDate(date)) {
+        return new Intl.DateTimeFormat(undefined, {
+            hour: 'numeric',
+            minute: 'numeric',
+            second: 'numeric',
+        }).format(date);
+    }
+    return '';
 };
 
 export const text = (value) => {

--- a/packages/record/src/components/RecordField/index.js
+++ b/packages/record/src/components/RecordField/index.js
@@ -79,7 +79,12 @@ RecordField.propTypes = {
     /** The label of the component. */
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     /** The value of the component. */
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.node,
+        PropTypes.number,
+        PropTypes.object,
+    ]),
     /** The type prop specifies the format that the component will have, by default is text. */
     type: PropTypes.oneOf([
         'text',
@@ -107,7 +112,7 @@ RecordField.propTypes = {
     /**
      * The component class or function that is going to be render if you pass a custom component to the RecordField
      */
-    component: PropTypes.func,
+    component: PropTypes.element,
 };
 
 RecordField.defaultProps = {


### PR DESCRIPTION
#240 