### PR TITLE
fix: add tabindex={-1} to the close button in inputSearch component in the search module

### DIFF
--- a/packages/search/src/components/InputSearch/trailing.tsx
+++ b/packages/search/src/components/InputSearch/trailing.tsx
@@ -12,7 +12,12 @@ const Trailing = React.forwardRef<HTMLDivElement, TrailingProps>(
         return (
             <StyledTrailing ref={ref}>
                 <RenderIf isTrue={value}>
-                    <StyledButtonIcon icon={<Close />} size="x-small" onClick={onClear} />
+                    <StyledButtonIcon
+                        icon={<Close />}
+                        size="x-small"
+                        onClick={onClear}
+                        tabIndex={-1}
+                    />
                 </RenderIf>
                 <RenderIf isTrue={shouldRenderDivider}>
                     <Divider />


### PR DESCRIPTION
fix: #645 